### PR TITLE
Fix Changelog tag links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Initial Release
 - Plugin with 100% test Coverage
 
-[0.3.2]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.1...v0.3.2
-[0.3.1]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.0...v0.3.1
-[0.3.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.2.2...v0.3.0
-[0.2.2]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.2.1...v0.2.2
-[0.2.1]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.1.0...v0.2.1
-[0.1.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.0...v0.1.0
+[0.3.2]: https://github.com/sandrina-p/postcss-start-to-end/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/sandrina-p/postcss-start-to-end/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/sandrina-p/postcss-start-to-end/compare/v0.2.2...v0.3.0
+[0.2.2]: https://github.com/sandrina-p/postcss-start-to-end/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/sandrina-p/postcss-start-to-end/compare/v0.1.0...v0.2.1
+[0.1.0]: https://github.com/sandrina-p/postcss-start-to-end/tags/v0.1.0


### PR DESCRIPTION
Greetings,

just a few updates in the Changelog tag links, also tags are not pushed to Github.

