### PR TITLE
Feature/add option ignore node modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
--
+- Add option `ignoreNodeModules` that ignores any CSS file inside `/node_modules` folder.
 
 ### Changed
 - Tests on /convert needed

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ postcss([
 ## Options
 
 #### `direction`
-Default writing mode of CSS.  
-**Type:** `string`  
-**Default:** `'LTR'`  
-**Values:** `'LTR'`, `'RTL'`  
+Default writing mode of CSS.
+**Type:** `string`
+**Default:** `'LTR'`
+**Values:** `'LTR'`, `'RTL'`
 
 **Input**
 ```css
@@ -78,10 +78,10 @@ Default writing mode of CSS.
 ```
 
 #### `warnings`
-Output on CLI warnings about properties / rules found that don't follow start-to-end syntax.  
-**Type:** `boolean`  
-**Default:** `true`  
-**Values:** `true`, `false`  
+Output on CLI warnings about properties / rules found that don't follow start-to-end syntax.
+**Type:** `boolean`
+**Default:** `true`
+**Values:** `true`, `false`
 
 **Example**
 
@@ -97,6 +97,12 @@ Output on CLI warnings about properties / rules found that don't follow start-to
 **Console warning if `direction: rtl:`**
 >  margin-left: 10%; found on line 2. Replace it by `margin-end` to support LTR and RTL directions.
 
+
+#### `ignoreNodeModules`
+Ignore any CSS file inside `/node_modules` folder.
+**Type:** `boolean`
+**Default:** `true`
+**Values:** `true`, `false`
 
 
 ## Rules supported
@@ -149,13 +155,13 @@ You just need to tell where you want to run the converter (folder or file.css). 
 ```
 
 ### Convert from LTR layout
-_Convert_ by default runs on `src` folder  
+_Convert_ by default runs on `src` folder
 `node node_modules/postcss-start-to-end/convert`
 
-Set a specific folder to run:  
+Set a specific folder to run:
 `node node_modules/postcss-start-to-end/convert src/components`
 
-Set a specific file to run:  
+Set a specific file to run:
 `node node_modules/postcss-start-to-end/convert styles/index.css`
 
 **Output**
@@ -169,13 +175,13 @@ Set a specific file to run:
 
 ### Convert RTL layout
 
-_Convert_ by default runs on `src` folder    
+_Convert_ by default runs on `src` folder
 `node node_modules/postcss-start-to-end/convert --rtl`
 
-Set a specific folder to run:  
+Set a specific folder to run:
 `node node_modules/postcss-start-to-end/convert src/components --rtl`
 
-Set a specific file to run:  
+Set a specific file to run:
 `node node_modules/postcss-start-to-end/convert styles/index.css --rtl`
 
 **Output**
@@ -207,7 +213,7 @@ Then if you need to convert the outputted CSS to the opposite direction you migh
 
 ## Motivation | References
 
-There is a CSS Draft Spec about [CSS Logical Properties](https://drafts.csswg.org/css-logical-props/) in Level 1.  
+There is a CSS Draft Spec about [CSS Logical Properties](https://drafts.csswg.org/css-logical-props/) in Level 1.
 Because this technology's specification [has not stabilized](https://drafts.csswg.org/css-logical-props/#issues-index), I decided to keep this plugin syntax simple and straight following what is already defined without adding _more sugar_.
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/postcss-start-to-end.svg)](https://badge.fury.io/js/postcss-start-to-end)
 [![Build Status](https://travis-ci.org/sandrina-p/postcss-start-to-end.svg?branch=master)](https://travis-ci.org/sandrina-p/postcss-start-to-end)
-[![Coverage Status](https://coveralls.io/repos/github/sandrina-p/postcss-start-to-end/badge.svg)](https://coveralls.io/github/sandrina-p/postcss-start-to-end)
+<!-- [![Coverage Status](https://coveralls.io/repos/github/sandrina-p/postcss-start-to-end/badge.svg)](https://coveralls.io/github/sandrina-p/postcss-start-to-end) -->
 
 [PostCSS](https://github.com/postcss/postcss) plugin that lets you control your layout (`ltr` or `rtl`) through logical rather than direction / physical rules.
 

--- a/convert/index.js
+++ b/convert/index.js
@@ -1,6 +1,22 @@
 /* eslint-disable no-console */
 /* global process */
 
+/* ========================================================================
+Convert direction rules to logical rules.
+Ex: padding-left: 5px; -> padding-start: 5px;
+
+HOW TO USE:
+
+1. Copy this file to your project root.
+2. Run `node convert`
+    This will convert all *.css files inside /src
+    If you want to run it in other folder/file, just run
+    `node convert myfolder/file.css` or `node conver myfolder/`
+
+3. If, for some reason, some rule wasn't converted, open a issue.
+
+======================================================================== */
+
 var fs = require('fs');
 var path = require('path');
 var pathToConvert = 'src';
@@ -13,46 +29,59 @@ function convertNewValues(data, fileDir) {
         // replace "<prop>: <rule>"
         .replace(/margin-left:/g, `margin-${logic.left}:`)
         .replace(/margin-right:/g, `margin-${logic.right}:`)
+
         .replace(/padding-left:/g, `padding-${logic.left}:`)
         .replace(/padding-right:/g, `padding-${logic.right}:`)
+
         .replace(/border-left:/g, `border-${logic.left}:`)
         .replace(/border-right:/g, `border-${logic.right}:`)
         .replace(/border-top-left:/g, `border-top-${logic.left}:`)
         .replace(/border-top-right:/g, `border-top-${logic.right}:`)
         .replace(/border-bottom-right:/g, `border-bottom-${logic.right}:`)
         .replace(/border-bottom-left:/g, `border-bottom-${logic.left}:`)
+
         .replace(/left:/g, `${logic.left}:`)
         .replace(/right:/g, `${logic.right}:`)
+
         .replace(/text-align: left/g, `text-align: ${logic.left}`)
         .replace(/text-align: right/g, `text-align: ${logic.right}`)
+
         .replace(/clear: left/g, `clear: ${logic.left}`)
         .replace(/clear: right/g, `clear: ${logic.right}`)
+
         .replace(/float: left/g, `float: ${logic.left}`)
         .replace(/float: right/g, `float: ${logic.right}`)
 
         // replace "<prop> :"
         .replace(/margin-left :/g, `margin-${logic.left} :`)
         .replace(/margin-right :/g, `margin-${logic.right} :`)
+
         .replace(/padding-left :/g, `padding-${logic.left} :`)
         .replace(/padding-right :/g, `padding-${logic.right} :`)
+
         .replace(/border-left :/g, `border-${logic.left} :`)
         .replace(/border-right :/g, `border-${logic.right} :`)
         .replace(/border-top-left :/g, `border-top-${logic.left} :`)
         .replace(/border-top-right :/g, `border-top-${logic.right} :`)
         .replace(/border-bottom-right :/g, `border-bottom-${logic.right} :`)
         .replace(/border-bottom-left :/g, `border-bottom-${logic.left} :`)
+
         .replace(/left :/g, `${logic.left} :`)
         .replace(/right :/g, `${logic.right} :`)
+
         .replace(/text-align : left/g, `text-align : ${logic.left}`)
         .replace(/text-align : right/g, `text-align : ${logic.right}`)
+
         .replace(/clear : left/g, `clear : ${logic.left}`)
         .replace(/clear : right/g, `clear : ${logic.right}`)
+
         .replace(/float : left/g, `float : ${logic.left}`)
         .replace(/float : right/g, `float : ${logic.right}`)
 
         // replace "<prop>:<rule>"
         .replace(/clear:left/g, `clear:${logic.left}`)
         .replace(/clear:right/g, `clear:${logic.right}`)
+
         .replace(/float:left/g, `float:${logic.left}`)
         .replace(/float:right/g, `float:${logic.right}`);
     return newData;

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var postcss = require('postcss');
 const defaultOpts = {
     direction: 'LTR',
     warnings: true,
-    ignoreNodeModules: false,
+    ignoreNodeModules: true,
 };
 
 const propsToConvert = [

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ var postcss = require('postcss');
 
 const defaultOpts = {
     direction: 'LTR',
-    warnings: true
+    warnings: true,
+    ignoreNodeModules: false,
 };
 
 const propsToConvert = [
@@ -153,6 +154,9 @@ module.exports = postcss.plugin('postcss-start-to-end', opts => {
 
         // Transform CSS AST
         root.walkDecls(rule => {
+            if (finalOpts.ignoreNodeModules && rule.source.input.file && rule.source.input.file.indexOf('/node_modules') > 0) {
+                return false;
+            }
 
             if (rule.value) {
                 if (finalOpts.warnings) {

--- a/index.test.js
+++ b/index.test.js
@@ -79,6 +79,7 @@ it('RTL: padding-end -> padding-left:', () => {
     return run(css, cssOutputted, { direction: 'RTL' });
 });
 
+// With 4 values
 it('LTR: padding: 1rem 1rem 1rem 2rem; -> same', () => {
     css = '.foo { padding: 1rem 1rem 1rem 2rem; }';
 
@@ -148,6 +149,45 @@ it('RTL: margin-end -> margin-left:', () => {
     cssOutputted = '.foo { margin-left: 1rem; }';
 
     return run(css, cssOutputted, { direction: 'RTL' });
+});
+
+// With 4 values
+it('LTR: margin: 1rem 1rem 1rem 2rem; -> same', () => {
+    css = '.foo { margin: 1rem 1rem 1rem 2rem; }';
+
+    return run(css, css, {});
+});
+
+it('LTR: margin: 1rem 2rem 1rem; -> same', () => {
+    css = '.foo { margin: 1rem 1rem 2rem; }';
+
+    return run(css, css, {});
+});
+
+it('LTR: margin: 1rem 1rem   1rem  2rem; -> same', () => {
+    css = '.foo { margin: 1rem 1rem   1rem  2rem; }';
+
+    return run(css, css, {});
+});
+
+it('RTL: margin: 1rem 2rem 1rem 2rem; -> margin: 1rem 2rem 1rem 1rem;', () => {
+    css = '.foo { margin: 1rem 1rem 1rem 2rem; }';
+    cssOutputted = '.foo { margin: 1rem 2rem 1rem 1rem; }';
+
+    return run(css, cssOutputted, { direction: 'RTL' });
+});
+
+it('RTL: margin: 1rem 1rem   1rem  3rem; -> margin: 1rem 3rem 1rem 1rem;', () => {
+    css = '.foo { margin: 1rem 1rem   1rem  3rem; }';
+    cssOutputted = '.foo { margin: 1rem 3rem 1rem 1rem; }';
+
+    return run(css, cssOutputted, { direction: 'RTL' });
+});
+
+it('RTL: margin: 1rem 1rem 3rem; -> same', () => {
+    css = '.foo { margin: 1rem 1rem 3rem; }';
+
+    return run(css, css, { direction: 'RTL' });
 });
 
 /* ==================================================================
@@ -372,4 +412,39 @@ it('LTR: Do not warn when `warning: disabled`', () => {
     css = '.foo { text-align: left; }';
 
     return run(css, css, { warnings: false });
+});
+
+/* ==================================================================
+    ignoreNodeModules test
+================================================================== */
+it('Do not modify or warn if file path is on node_modules`', () => {
+    css = '.foo { text-align: left; }';
+    cssOutputted = css;
+
+    return postcss([ plugin() ]).process(css, { from: 'test/node_modules/package/' })
+        .then(result => {
+            expect(result.css).toEqual(cssOutputted);
+            expect(result.warnings().length).toBe(0);
+        });
+});
+
+it('Modify and warn if file path is not on node_modules`', () => {
+    css = '.foo { float: right; }';
+    const warning = '"float: right;" found on line 1. Replace it by "float: end;" to support LTR and RTL';
+
+    return postcss([ plugin() ]).process(css,  { from: 'test/component/' })
+        .then(result => {
+            expect(result.css).toEqual(css);
+            expect(result.warnings()[0]).toHaveProperty('text', warning);
+        });
+});
+
+/* ==================================================================
+    Empty rules test
+================================================================== */
+
+it('Do nothing if rule doesnt have value', () => {
+    css = '.foo { text-align:; }';
+
+    return run(css, css);
 });


### PR DESCRIPTION
### Added
- Add option `ignoreNodeModules` that ignores any CSS file inside `/node_modules` folder.

Release: 0.3.4