### PR TITLE
Update PostCSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   },
   "devDependencies": {
     "coveralls": "^2.13.1",
-    "eslint": "^3.12.2",
+    "eslint": "^3.19.0",
     "eslint-config-postcss": "^2.0.2",
-    "jest": "^18.0.0"
+    "jest": "^20.0.4"
   },
   "scripts": {
     "test": "jest --coverage && eslint *.js"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/sandrina-p/postcss-start-to-end",
   "dependencies": {
-    "postcss": "^5.2.6",
+    "postcss": "^6.0.1",
     "postcss-reporter": "3.x.x"
   },
   "devDependencies": {


### PR DESCRIPTION
There were a lot of changes in PostCSS 6, including performance improvements and formally moving to Node 4+.